### PR TITLE
feat: add typescript types

### DIFF
--- a/hypertag.d.ts
+++ b/hypertag.d.ts
@@ -1,0 +1,11 @@
+export declare type TagsSpecifier = string | string[];
+export declare type Attr = string | true;
+export interface ParseOptions {
+    tagKey?: string;
+}
+declare function extend(tags: TagsSpecifier, options: ParseOptions): (source: string) => (Record<string, Attr> | undefined)[];
+declare function parse(source: string, tags: TagsSpecifier, options: ParseOptions): (Record<string, Attr> | undefined)[];
+declare function parseAttrs(htmlTagText: string, tagKey?: string): Record<string, Attr> | undefined;
+declare function stripComments(html: string): string;
+export { extend, parse, parseAttrs, stripComments };
+export default parse;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "umd:main": "dist/index.umd.js",
   "module": "dist/index.mjs",
   "source": "hypertag.js",
+  "types": "hypertag.d.ts",
   "scripts": {
     "build": "rimraf dist && microbundle",
     "test": "nyc ava",


### PR DESCRIPTION
## Changes

This PR adds missing types from TypeScript, but doesn’t fix the broken ES build as that would require a breaking API change (see comment below).

Resolves #2.

## Testing

This PR doesn’t change any core code as intended, so no tests need to be updated nor manual tests done